### PR TITLE
use log from own version to prevent two instances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,5 @@ module github.com/neko-neko/echo-logrus/v2
 require (
 	github.com/labstack/echo/v4 v4.0.0
 	github.com/labstack/gommon v0.2.8
-	github.com/neko-neko/echo-logrus v1.1.0
 	github.com/sirupsen/logrus v1.3.0
 )

--- a/middleware.go
+++ b/middleware.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"github.com/neko-neko/echo-logrus/log"
+	"github.com/neko-neko/echo-logrus/v2/log"
 )
 
 // Logger returns a middleware that logs HTTP requests.


### PR DESCRIPTION
When using echo-logrus/v2, the middleware implementation will reference an instance from the v1.1.0 version without the version in the path, hence there will be two instances with potential different configurations